### PR TITLE
Add Sticky Headers to search table

### DIFF
--- a/src/app/components/browse/result-table/result-table.component.scss
+++ b/src/app/components/browse/result-table/result-table.component.scss
@@ -17,4 +17,9 @@
   thead>tr:first-child>th:last-child {
     border-radius: 0px;
   }
+  th {
+    position: sticky;
+    top: 0;
+    z-index:1;
+  }
 }

--- a/src/assets/themes/dark.css
+++ b/src/assets/themes/dark.css
@@ -102,6 +102,9 @@ html,
 .ui.menu {
   background-color: var(--dk-08dp) !important;
 }
+.ui #resultTable th {
+  background: rgb(61,61,61) !important;
+}
 
 /* #region Buttons */
 


### PR DESCRIPTION
Applies css to #resultTable.th to create a sticky header effect. 

Tested on browser and windows10.