### PR TITLE
update electron-builder mac target to include x64 and arm64 versions

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -23,7 +23,13 @@
   "mac": {
     "category": "public.app-category.utilities",
     "target": [
-      "dmg"
+      {
+				"target": "dmg",
+				"arch": [
+					"x64",
+					"arm64"
+				]
+			}
     ],
     "icon": "dist/angular/assets/images/system/icons/mac/icon.icns"
   },


### PR DESCRIPTION
Tested out building locally, and had both `Bridge-2.1.0-arm64.dmg` and `Bridge-2.1.0.dmg` files. I installed the Bridge-2.1.0.dmg file locally and was able to run Bridge on my Intel mac.

closes #55 