### PR TITLE
Add sortable charter column

### DIFF
--- a/src-angular/app/components/browse/result-table/result-table-row/result-table-row.component.html
+++ b/src-angular/app/components/browse/result-table/result-table-row/result-table-row.component.html
@@ -8,4 +8,5 @@
 <td>{{ song[0].album || 'Various' }}</td>
 <td>{{ song[0].genre || 'Various' }}</td>
 <td>{{ song[0].year || 'Various' }}</td>
+<td>{{ song[0].charter || 'Various' | removeStyleTags }}</td>
 <!-- TODO: "Various" will never display -->

--- a/src-angular/app/components/browse/result-table/result-table.component.html
+++ b/src-angular/app/components/browse/result-table/result-table.component.html
@@ -24,6 +24,9 @@
 				<th [ngClass]="sortDirection" (click)="onColClicked('year')">
 					Year <i *ngIf="sortColumn === 'year'" class="bi bi-caret-{{ sortDirection === 'ascending' ? 'down' : 'up' }}-fill"></i>
 				</th>
+				<th [ngClass]="sortDirection" (click)="onColClicked('charter')">
+					Charter <i *ngIf="sortColumn === 'charter'" class="bi bi-caret-{{ sortDirection === 'ascending' ? 'down' : 'up' }}-fill"></i>
+				</th>
 			</tr>
 		</thead>
 		<tbody>

--- a/src-angular/app/components/browse/result-table/result-table.component.ts
+++ b/src-angular/app/components/browse/result-table/result-table.component.ts
@@ -23,7 +23,7 @@ export class ResultTableComponent implements OnInit {
 
 	activeSong: ChartData[] | null = null
 	sortDirection: 'ascending' | 'descending' = 'ascending'
-	sortColumn: 'name' | 'artist' | 'album' | 'genre' | 'year' | null = null
+	sortColumn: 'name' | 'artist' | 'album' | 'genre' | 'year' | 'charter' | null = null
 
 	constructor(
 		public searchService: SearchService,
@@ -58,7 +58,7 @@ export class ResultTableComponent implements OnInit {
 		}
 	}
 
-	onColClicked(column: 'name' | 'artist' | 'album' | 'genre' | 'year') {
+	onColClicked(column: 'name' | 'artist' | 'album' | 'genre' | 'year' | 'charter') {
 		if (this.songs.length === 0) { return }
 		if (this.sortColumn !== column) {
 			this.sortColumn = column


### PR DESCRIPTION
Hello 👋 

This PR adds a sortable charter column to the results table. I found myself wanting to see this information when trying to find all the first-party charts for a given band, as demonstrated in the attached screenshot showing this change:

![image](https://github.com/Geomitron/Bridge/assets/873012/36bd4fe1-71aa-4d34-9632-6e1cc39715dd)

Cheers,
Alex