### PR TITLE
Fixes arm64 build to universal package

### DIFF
--- a/electron-builder.json
+++ b/electron-builder.json
@@ -27,8 +27,7 @@
 			{
 				"target": "dmg",
 				"arch": [
-					"x64",
-					"arm64"
+					"universal"
 				]
 			}
 		],


### PR DESCRIPTION
## Problem
The arm64 builds are flagged as "damaged" by macOS due to lack of signature

## Evidence
![image](https://github.com/user-attachments/assets/70bd2ba8-37ed-46bf-a2d5-c543126c33d2)

## Solution
Using universal builds fixes the package and runs on native instructions, with the cost of making the final `.dmg` twice as big.

## Evidence
![Screenshot 2024-08-04 at 19 11 01](https://github.com/user-attachments/assets/d72d3bec-2e4a-4c14-9450-a57c8eca3e55)
