### PR TITLE
Add song list feature for organizing and sharing charts

### DIFF
--- a/src-angular/app/app-routing.module.ts
+++ b/src-angular/app/app-routing.module.ts
@@ -3,12 +3,16 @@ import { RouteReuseStrategy, RouterModule, Routes } from '@angular/router'
 
 import { BrowseComponent } from './components/browse/browse.component'
 import { SettingsComponent } from './components/settings/settings.component'
+import { SongListsComponent } from './components/songlists/songlists.component'
+import { SongListDetailComponent } from './components/songlists/songlist-detail/songlist-detail.component'
 import { ToolsComponent } from './components/tools/tools.component'
 import { TabPersistStrategy } from './core/tab-persist.strategy'
 
 const routes: Routes = [
 	{ path: 'browse', component: BrowseComponent, data: { shouldReuse: true } },
 	{ path: 'library', redirectTo: '/browse' },
+	{ path: 'lists', component: SongListsComponent, data: { shouldReuse: true } },
+	{ path: 'lists/:id', component: SongListDetailComponent },
 	{ path: 'tools', component: ToolsComponent, data: { shouldReuse: true } },
 	{ path: 'settings', component: SettingsComponent, data: { shouldReuse: true } },
 	{ path: 'about', redirectTo: '/browse' },

--- a/src-angular/app/app.component.ts
+++ b/src-angular/app/app.component.ts
@@ -1,6 +1,7 @@
 import { Component } from '@angular/core'
 
 import { SettingsService } from './core/services/settings.service'
+import { SongListService } from './core/services/songlist.service'
 
 @Component({
 	selector: 'app-root',
@@ -12,9 +13,11 @@ export class AppComponent {
 
 	settingsLoaded = false
 
-	constructor(settingsService: SettingsService) {
+	constructor(settingsService: SettingsService, songListService: SongListService) {
 		// Ensure settings are loaded before rendering the application
 		settingsService.loadSettings().then(() => this.settingsLoaded = true)
+		// Load song lists in the background (not critical for initial render)
+		songListService.loadLists()
 
 		document.addEventListener('keydown', event => {
 			if (event.ctrlKey && (event.key === '+' || event.key === '-' || event.key === '=' || event.key === '0')) {

--- a/src-angular/app/app.module.ts
+++ b/src-angular/app/app.module.ts
@@ -16,7 +16,11 @@ import { SearchBarComponent } from './components/browse/search-bar/search-bar.co
 import { DownloadsModalComponent } from './components/browse/status-bar/downloads-modal/downloads-modal.component'
 import { StatusBarComponent } from './components/browse/status-bar/status-bar.component'
 import { SettingsComponent } from './components/settings/settings.component'
+import { SongListsComponent } from './components/songlists/songlists.component'
+import { SongListDetailComponent } from './components/songlists/songlist-detail/songlist-detail.component'
+import { AddToListModalComponent } from './components/songlists/add-to-list-modal/add-to-list-modal.component'
 import { ToolbarComponent } from './components/toolbar/toolbar.component'
+import { ToolsComponent } from './components/tools/tools.component'
 import { RemoveStyleTagsPipe } from './core/pipes/remove-style-tags.pipe'
 
 @NgModule({
@@ -35,6 +39,10 @@ import { RemoveStyleTagsPipe } from './core/pipes/remove-style-tags.pipe'
 		DownloadsModalComponent,
 		RemoveStyleTagsPipe,
 		SettingsComponent,
+		SongListsComponent,
+		SongListDetailComponent,
+		AddToListModalComponent,
+		ToolsComponent,
 	],
 	bootstrap: [AppComponent], imports: [
 		BrowserModule,

--- a/src-angular/app/components/browse/chart-sidebar/chart-sidebar.component.html
+++ b/src-angular/app/components/browse/chart-sidebar/chart-sidebar.component.html
@@ -143,6 +143,12 @@
 		</div>
 		<div class="join">
 			<button class="btn rounded-md flex-1 join-item btn-primary capitalize" (click)="onDownloadClicked()">Download</button>
+			<button
+				class="btn rounded-md join-item btn-neutral tooltip tooltip-top"
+				data-tip="Add to List"
+				(click)="onAddToListClicked()">
+				<i class="bi bi-collection text-lg"></i>
+			</button>
 			<div
 				#menu
 				class="cursor-pointer bg-neutral rounded-md join-item dropdown dropdown-top dropdown-end p-1 flex items-center"
@@ -166,5 +172,6 @@
 				</form>
 			</dialog>
 		</div>
+		<app-add-to-list-modal #addToListModal />
 	</div>
 }

--- a/src-angular/app/components/browse/chart-sidebar/chart-sidebar.component.ts
+++ b/src-angular/app/components/browse/chart-sidebar/chart-sidebar.component.ts
@@ -9,6 +9,7 @@ import { SettingsService } from 'src-angular/app/core/services/settings.service'
 import { ChartData } from 'src-shared/interfaces/search.interface'
 import { setlistNames } from 'src-shared/setlist-names'
 import { difficulties, difficultyDisplay, driveLink, hasIssues, instruments, msToRoughTime, removeStyleTags, shortInstrumentDisplay } from 'src-shared/UtilFunctions'
+import { AddToListModalComponent } from '../../songlists/add-to-list-modal/add-to-list-modal.component'
 
 @Component({
 	selector: 'app-chart-sidebar',
@@ -20,6 +21,7 @@ export class ChartSidebarComponent implements OnInit {
 
 	@ViewChild('menu') menu: ElementRef
 	@ViewChild('libraryDirectoryErrorModal') libraryDirectoryErrorModal: ElementRef<HTMLDialogElement>
+	@ViewChild('addToListModal') addToListModal: AddToListModalComponent
 
 	public shortInstrumentDisplay = shortInstrumentDisplay
 	public difficultyDisplay = difficultyDisplay
@@ -291,5 +293,11 @@ export class ChartSidebarComponent implements OnInit {
 				}
 			}
 		})
+	}
+
+	onAddToListClicked() {
+		if (this.selectedChart) {
+			this.addToListModal.open([this.selectedChart])
+		}
 	}
 }

--- a/src-angular/app/components/browse/status-bar/status-bar.component.html
+++ b/src-angular/app/components/browse/status-bar/status-bar.component.html
@@ -2,9 +2,13 @@
 	<div *ngIf="searchService.songsResponse" class="text-nowrap">
 		{{ searchService.songsResponse.found | number: '1.0-0' }} Result{{ searchService.songsResponse.found === 1 ? '' : 's' }}
 	</div>
-	<div class="flex-1">
+	<div class="flex-1 flex gap-2">
 		<button *ngIf="selectedGroupIds.length > 1" (click)="downloadSelected()" class="btn btn-sm btn-primary text-nowrap">
 			Download {{ selectedGroupIds.length }} Results
+		</button>
+		<button *ngIf="selectedGroupIds.length > 1" (click)="addSelectedToList()" class="btn btn-sm btn-neutral text-nowrap">
+			<i class="bi bi-collection"></i>
+			Add to List
 		</button>
 	</div>
 	<div *ngIf="downloadService.downloadCount > 0" class="text-ellipsis text-nowrap overflow-hidden whitespace-nowrap max-w-full">
@@ -33,4 +37,6 @@
 			<button>close</button>
 		</form>
 	</dialog>
+
+	<app-add-to-list-modal #addToListModal />
 </div>

--- a/src-angular/app/components/browse/status-bar/status-bar.component.ts
+++ b/src-angular/app/components/browse/status-bar/status-bar.component.ts
@@ -6,6 +6,7 @@ import { removeStyleTags } from '../../../../../src-shared/UtilFunctions.js'
 import { DownloadService } from '../../../core/services/download.service'
 import { SearchService } from '../../../core/services/search.service'
 import { SelectionService } from '../../../core/services/selection.service'
+import { AddToListModalComponent } from '../../songlists/add-to-list-modal/add-to-list-modal.component'
 
 @Component({
 	selector: 'app-status-bar',
@@ -15,6 +16,7 @@ import { SelectionService } from '../../../core/services/selection.service'
 export class StatusBarComponent {
 
 	@ViewChild('downloadsModal', { static: false }) downloadsModalComponent: ElementRef
+	@ViewChild('addToListModal') addToListModal: AddToListModalComponent
 
 	constructor(
 		public downloadService: DownloadService,
@@ -45,5 +47,16 @@ export class StatusBarComponent {
 
 	clearCompleted() {
 		this.downloadService.cancelAllCompleted()
+	}
+
+	addSelectedToList() {
+		const selectedGroupIds = this.selectedGroupIds
+		const selectedCharts = this.searchService.groupedSongs.filter(gs => selectedGroupIds.includes(gs[0].groupId))
+
+		const uniqueCharts = _.uniqBy(selectedCharts, gs => `${removeStyleTags(gs[0].artist ?? 'Unknown Artist')
+			} - ${removeStyleTags(gs[0].name ?? 'Unknown Name')
+			} (${removeStyleTags(gs[0].charter ?? 'Unknown Charter')})`).map(gs => gs[0])
+
+		this.addToListModal.open(uniqueCharts)
 	}
 }

--- a/src-angular/app/components/settings/settings.component.html
+++ b/src-angular/app/components/settings/settings.component.html
@@ -42,7 +42,7 @@
 								<div class="text-xs">{{ '{name}, {artist}, {album}, {genre}, {year}, {charter}' }}</div>
 								<br />
 								Example:
-								<div class="text-xs">"{artist}/{name} ({charter})" will create chart folders that look like "{name} ({charter})" inside subfolders that look like "{artist}"</div>
+								<div class="text-xs">"{{ '{artist}' }}/{{ '{name}' }} ({{ '{charter}' }})" will create chart folders that look like "{{ '{name}' }} ({{ '{charter}' }})" inside subfolders that look like "{{ '{artist}' }}"</div>
 							</ul>
 						</div>
 					</div>

--- a/src-angular/app/components/songlists/add-to-list-modal/add-to-list-modal.component.html
+++ b/src-angular/app/components/songlists/add-to-list-modal/add-to-list-modal.component.html
@@ -1,0 +1,96 @@
+<!-- Main Add to List Modal -->
+<dialog #addToListModal class="modal">
+	<div class="modal-box bg-base-100 text-base-content">
+		<form method="dialog">
+			<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+				<i class="bi bi-x-lg text-lg"></i>
+			</button>
+		</form>
+		<h3 class="text-lg font-bold mb-2">Add to List</h3>
+		<p class="text-sm text-base-content/70 mb-4">{{ chartDescription }}</p>
+
+		@if (lists.length === 0) {
+			<div class="text-center py-8 text-base-content/60">
+				<i class="bi bi-collection text-4xl mb-2"></i>
+				<p>No song lists yet</p>
+				<p class="text-sm">Create your first list to get started</p>
+			</div>
+		} @else {
+			<div class="max-h-64 overflow-y-auto">
+				@for (list of lists; track list.id) {
+					<label class="flex items-center gap-3 p-2 hover:bg-base-200 rounded cursor-pointer">
+						<input
+							type="checkbox"
+							class="checkbox"
+							[checked]="isSelected(list.id)"
+							[indeterminate]="isPartiallyInList(list) && !isSelected(list.id)"
+							(change)="toggleList(list.id)" />
+						<div class="flex-1 min-w-0">
+							<p class="font-medium truncate">{{ list.name }}</p>
+							<p class="text-xs text-base-content/60">{{ list.entries.length }} songs</p>
+						</div>
+					</label>
+				}
+			</div>
+		}
+
+		<div class="divider my-2"></div>
+
+		<button class="btn btn-ghost btn-sm w-full justify-start" (click)="openCreateNewList()">
+			<i class="bi bi-plus-lg"></i>
+			Create new list
+		</button>
+
+		<div class="modal-action">
+			<form method="dialog">
+				<button class="btn btn-ghost">Cancel</button>
+			</form>
+			<button class="btn btn-primary" (click)="save()">Save</button>
+		</div>
+	</div>
+	<form method="dialog" class="modal-backdrop">
+		<button>close</button>
+	</form>
+</dialog>
+
+<!-- Create New List Modal (nested) -->
+<dialog #createNewListModal class="modal">
+	<div class="modal-box bg-base-100 text-base-content">
+		<form method="dialog">
+			<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+				<i class="bi bi-x-lg text-lg"></i>
+			</button>
+		</form>
+		<h3 class="text-lg font-bold mb-4">Create New List</h3>
+		<div class="form-control mb-4">
+			<label class="label">
+				<span class="label-text">Name</span>
+			</label>
+			<input
+				type="text"
+				[formControl]="newListName"
+				class="input input-bordered"
+				placeholder="My Song List"
+				(keydown.enter)="createNewList()" />
+		</div>
+		<div class="form-control mb-4">
+			<label class="label">
+				<span class="label-text">Description (optional)</span>
+			</label>
+			<textarea
+				[formControl]="newListDescription"
+				class="textarea textarea-bordered"
+				placeholder="A collection of songs..."
+				rows="2"></textarea>
+		</div>
+		<div class="modal-action">
+			<form method="dialog">
+				<button class="btn btn-ghost">Cancel</button>
+			</form>
+			<button class="btn btn-primary" [disabled]="!newListName.valid" (click)="createNewList()">Create</button>
+		</div>
+	</div>
+	<form method="dialog" class="modal-backdrop">
+		<button>close</button>
+	</form>
+</dialog>

--- a/src-angular/app/components/songlists/add-to-list-modal/add-to-list-modal.component.ts
+++ b/src-angular/app/components/songlists/add-to-list-modal/add-to-list-modal.component.ts
@@ -1,0 +1,141 @@
+import { ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core'
+import { FormControl, Validators } from '@angular/forms'
+
+import { SongList } from '../../../../../src-shared/interfaces/songlist.interface.js'
+import { ChartData } from '../../../../../src-shared/interfaces/search.interface.js'
+import { SongListService } from '../../../core/services/songlist.service'
+
+@Component({
+	selector: 'app-add-to-list-modal',
+	templateUrl: './add-to-list-modal.component.html',
+	standalone: false,
+})
+export class AddToListModalComponent implements OnInit, OnDestroy {
+	@ViewChild('addToListModal') modal: ElementRef<HTMLDialogElement>
+	@ViewChild('createNewListModal') createNewListModal: ElementRef<HTMLDialogElement>
+
+	lists: SongList[] = []
+	charts: ChartData[] = []
+	selectedListIds = new Set<string>()
+
+	newListName = new FormControl<string>('', { nonNullable: true, validators: [Validators.required] })
+	newListDescription = new FormControl<string>('', { nonNullable: true })
+
+	private listsChangedSub: any
+
+	constructor(
+		private songListService: SongListService,
+		private ref: ChangeDetectorRef,
+	) { }
+
+	ngOnInit() {
+		this.lists = this.songListService.getLists()
+		this.listsChangedSub = this.songListService.listsChanged.subscribe(lists => {
+			this.lists = lists
+			this.ref.detectChanges()
+		})
+	}
+
+	ngOnDestroy() {
+		if (this.listsChangedSub) {
+			this.listsChangedSub.unsubscribe()
+		}
+	}
+
+	/**
+	 * Opens the modal to add charts to lists.
+	 * @param charts The charts to add
+	 */
+	open(charts: ChartData[]) {
+		this.charts = charts
+		this.selectedListIds.clear()
+
+		// Pre-select lists that already contain all the charts
+		for (const list of this.lists) {
+			const allChartsInList = charts.every(chart =>
+				list.entries.some(e => e.md5 === chart.md5)
+			)
+			if (allChartsInList) {
+				this.selectedListIds.add(list.id)
+			}
+		}
+
+		this.modal.nativeElement.showModal()
+	}
+
+	toggleList(listId: string) {
+		if (this.selectedListIds.has(listId)) {
+			this.selectedListIds.delete(listId)
+		} else {
+			this.selectedListIds.add(listId)
+		}
+	}
+
+	isSelected(listId: string): boolean {
+		return this.selectedListIds.has(listId)
+	}
+
+	isPartiallyInList(list: SongList): boolean {
+		const inListCount = this.charts.filter(chart =>
+			list.entries.some(e => e.md5 === chart.md5)
+		).length
+		return inListCount > 0 && inListCount < this.charts.length
+	}
+
+	openCreateNewList() {
+		this.newListName.reset()
+		this.newListDescription.reset()
+		this.createNewListModal.nativeElement.showModal()
+	}
+
+	async createNewList() {
+		if (this.newListName.valid) {
+			const newList = await this.songListService.createList(
+				this.newListName.value.trim(),
+				this.newListDescription.value.trim()
+			)
+			this.createNewListModal.nativeElement.close()
+
+			// Auto-select the newly created list
+			this.selectedListIds.add(newList.id)
+			this.ref.detectChanges()
+		}
+	}
+
+	save() {
+		// Add charts to newly selected lists
+		for (const listId of this.selectedListIds) {
+			const list = this.lists.find(l => l.id === listId)
+			if (list) {
+				// Filter out charts already in this list
+				const chartsToAdd = this.charts.filter(chart =>
+					!list.entries.some(e => e.md5 === chart.md5)
+				)
+				if (chartsToAdd.length > 0) {
+					this.songListService.addCharts(listId, chartsToAdd)
+				}
+			}
+		}
+
+		// Remove charts from deselected lists
+		for (const list of this.lists) {
+			if (!this.selectedListIds.has(list.id)) {
+				const chartsToRemove = this.charts.filter(chart =>
+					list.entries.some(e => e.md5 === chart.md5)
+				)
+				if (chartsToRemove.length > 0) {
+					this.songListService.removeCharts(list.id, chartsToRemove.map(c => c.md5))
+				}
+			}
+		}
+
+		this.modal.nativeElement.close()
+	}
+
+	get chartDescription(): string {
+		if (this.charts.length === 1) {
+			return `"${this.charts[0].name}" by ${this.charts[0].artist}`
+		}
+		return `${this.charts.length} songs`
+	}
+}

--- a/src-angular/app/components/songlists/songlist-detail/songlist-detail.component.html
+++ b/src-angular/app/components/songlists/songlist-detail/songlist-detail.component.html
@@ -1,0 +1,196 @@
+<div class="p-8 flex flex-col gap-4 h-full">
+	@if (!list) {
+		<div class="flex-1 flex flex-col items-center justify-center text-base-content/60">
+			<i class="bi bi-question-circle text-6xl mb-4"></i>
+			<p class="text-lg">Song list not found</p>
+			<button class="btn btn-primary mt-4" (click)="goBack()">Back to Lists</button>
+		</div>
+	} @else {
+		<!-- Header -->
+		<div class="flex justify-between items-start">
+			<div class="flex items-center gap-4">
+				<button class="btn btn-ghost btn-square" (click)="goBack()">
+					<i class="bi bi-arrow-left text-xl"></i>
+				</button>
+				<div>
+					<h1 class="text-2xl font-bold">{{ list.name }}</h1>
+					<p class="text-base-content/70">{{ list.description || 'No description' }}</p>
+					<p class="text-sm text-base-content/50 mt-1">
+						{{ list.entries.length }} songs | Created {{ formatDate(list.createdAt) }}
+					</p>
+				</div>
+			</div>
+			<div class="flex gap-2">
+				<button class="btn btn-ghost" (click)="openEditModal()">
+					<i class="bi bi-pencil"></i>
+					Edit
+				</button>
+				<button class="btn btn-neutral" (click)="exportList()">
+					<i class="bi bi-upload"></i>
+					Export
+				</button>
+			</div>
+		</div>
+
+		<!-- Actions Bar -->
+		@if (list.entries.length > 0) {
+			<div class="flex justify-between items-center bg-base-200 rounded-lg p-3">
+				<div class="flex items-center gap-4">
+					<label class="label cursor-pointer gap-2">
+						<input
+							type="checkbox"
+							class="checkbox"
+							[checked]="allSelected"
+							[indeterminate]="someSelected"
+							(change)="toggleSelectAll()" />
+						<span class="label-text">Select all</span>
+					</label>
+					@if (selectedEntries.size > 0) {
+						<span class="text-sm text-base-content/70">{{ selectedEntries.size }} selected</span>
+					}
+				</div>
+				<div class="flex gap-2">
+					@if (selectedEntries.size > 0) {
+						<button class="btn btn-error btn-sm" (click)="removeSelected()">
+							<i class="bi bi-trash"></i>
+							Remove Selected
+						</button>
+						<button class="btn btn-primary btn-sm" (click)="downloadSelected()">
+							<i class="bi bi-download"></i>
+							Download Selected
+						</button>
+					} @else {
+						<button class="btn btn-primary btn-sm" (click)="downloadAll()">
+							<i class="bi bi-download"></i>
+							Download All
+						</button>
+					}
+				</div>
+			</div>
+		}
+
+		<!-- Entries Table -->
+		@if (list.entries.length === 0) {
+			<div class="flex-1 flex flex-col items-center justify-center text-base-content/60">
+				<i class="bi bi-music-note-list text-6xl mb-4"></i>
+				<p class="text-lg">This list is empty</p>
+				<p class="text-sm">Add songs from the Browse tab to get started</p>
+			</div>
+		} @else {
+			<div class="overflow-x-auto flex-1">
+				<table class="table table-zebra">
+					<thead>
+						<tr>
+							<th class="w-12"></th>
+							<th>Name</th>
+							<th>Artist</th>
+							<th>Album</th>
+							<th>Charter</th>
+							<th>Added</th>
+							<th class="w-24">Actions</th>
+						</tr>
+					</thead>
+					<tbody>
+						@for (entry of list.entries; track entry.md5) {
+							<tr class="hover">
+								<td>
+									<input
+										type="checkbox"
+										class="checkbox checkbox-sm"
+										[checked]="isSelected(entry.md5)"
+										(change)="toggleSelection(entry.md5)" />
+								</td>
+								<td class="font-medium">{{ entry.cache.name || 'Unknown' }}</td>
+								<td>{{ entry.cache.artist || 'Unknown' }}</td>
+								<td>{{ entry.cache.album || 'Unknown' }}</td>
+								<td>{{ entry.cache.charter || 'Unknown' }}</td>
+								<td class="text-base-content/70">{{ formatDate(entry.addedAt) }}</td>
+								<td>
+									<div class="flex gap-1">
+										<button
+											class="btn btn-ghost btn-square btn-sm tooltip"
+											data-tip="Download"
+											(click)="downloadEntry(entry)">
+											<i class="bi bi-download"></i>
+										</button>
+										<button
+											class="btn btn-ghost btn-square btn-sm tooltip text-error"
+											data-tip="Remove"
+											(click)="confirmRemove(entry, $event)">
+											<i class="bi bi-trash"></i>
+										</button>
+									</div>
+								</td>
+							</tr>
+						}
+					</tbody>
+				</table>
+			</div>
+		}
+	}
+
+	<!-- Edit List Modal -->
+	<dialog #editListModal class="modal">
+		<div class="modal-box bg-base-100 text-base-content">
+			<form method="dialog">
+				<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+					<i class="bi bi-x-lg text-lg"></i>
+				</button>
+			</form>
+			<h3 class="text-lg font-bold mb-4">Edit Song List</h3>
+			<div class="form-control mb-4">
+				<label class="label">
+					<span class="label-text">Name</span>
+				</label>
+				<input
+					type="text"
+					[formControl]="editName"
+					class="input input-bordered"
+					(keydown.enter)="saveEdit()" />
+			</div>
+			<div class="form-control mb-4">
+				<label class="label">
+					<span class="label-text">Description</span>
+				</label>
+				<textarea
+					[formControl]="editDescription"
+					class="textarea textarea-bordered"
+					rows="2"></textarea>
+			</div>
+			<div class="modal-action">
+				<form method="dialog">
+					<button class="btn btn-ghost">Cancel</button>
+				</form>
+				<button class="btn btn-primary" [disabled]="!editName.valid" (click)="saveEdit()">Save</button>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop">
+			<button>close</button>
+		</form>
+	</dialog>
+
+	<!-- Remove Confirmation Modal -->
+	<dialog #removeConfirmModal class="modal">
+		<div class="modal-box bg-base-100 text-base-content">
+			<form method="dialog">
+				<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+					<i class="bi bi-x-lg text-lg"></i>
+				</button>
+			</form>
+			<h3 class="text-lg font-bold mb-4">Remove Song</h3>
+			@if (entryToRemove) {
+				<p>Remove "{{ entryToRemove.cache.name || 'Unknown' }}" from this list?</p>
+				<p class="text-sm text-base-content/70 mt-2">The song won't be deleted from your library.</p>
+			}
+			<div class="modal-action">
+				<form method="dialog">
+					<button class="btn btn-ghost">Cancel</button>
+				</form>
+				<button class="btn btn-error" (click)="removeEntry()">Remove</button>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop">
+			<button>close</button>
+		</form>
+	</dialog>
+</div>

--- a/src-angular/app/components/songlists/songlist-detail/songlist-detail.component.ts
+++ b/src-angular/app/components/songlists/songlist-detail/songlist-detail.component.ts
@@ -1,0 +1,174 @@
+import { ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core'
+import { FormControl, Validators } from '@angular/forms'
+import { ActivatedRoute, Router } from '@angular/router'
+
+import { SongList, SongListEntry } from '../../../../../src-shared/interfaces/songlist.interface.js'
+import { DownloadService } from '../../../core/services/download.service'
+import { SongListService } from '../../../core/services/songlist.service'
+
+@Component({
+	selector: 'app-songlist-detail',
+	templateUrl: './songlist-detail.component.html',
+	standalone: false,
+})
+export class SongListDetailComponent implements OnInit, OnDestroy {
+	@ViewChild('editListModal') editListModal: ElementRef<HTMLDialogElement>
+	@ViewChild('removeConfirmModal') removeConfirmModal: ElementRef<HTMLDialogElement>
+
+	list: SongList | null = null
+	selectedEntries = new Set<string>()
+
+	editName = new FormControl<string>('', { nonNullable: true, validators: [Validators.required] })
+	editDescription = new FormControl<string>('', { nonNullable: true })
+
+	entryToRemove: SongListEntry | null = null
+
+	private listsChangedSub: any
+
+	constructor(
+		private route: ActivatedRoute,
+		private router: Router,
+		private songListService: SongListService,
+		private downloadService: DownloadService,
+		private ref: ChangeDetectorRef,
+	) { }
+
+	ngOnInit() {
+		const listId = this.route.snapshot.paramMap.get('id')
+		if (listId) {
+			this.list = this.songListService.getList(listId) || null
+		}
+
+		this.listsChangedSub = this.songListService.listsChanged.subscribe(() => {
+			if (this.list) {
+				this.list = this.songListService.getList(this.list.id) || null
+				this.ref.detectChanges()
+			}
+		})
+	}
+
+	ngOnDestroy() {
+		if (this.listsChangedSub) {
+			this.listsChangedSub.unsubscribe()
+		}
+	}
+
+	goBack() {
+		this.router.navigate(['/lists'])
+	}
+
+	openEditModal() {
+		if (this.list) {
+			this.editName.setValue(this.list.name)
+			this.editDescription.setValue(this.list.description)
+			this.editListModal.nativeElement.showModal()
+		}
+	}
+
+	saveEdit() {
+		if (this.list && this.editName.valid) {
+			const updatedList: SongList = {
+				...this.list,
+				name: this.editName.value.trim(),
+				description: this.editDescription.value.trim(),
+			}
+			this.songListService.updateList(updatedList)
+			this.editListModal.nativeElement.close()
+		}
+	}
+
+	toggleSelection(md5: string) {
+		if (this.selectedEntries.has(md5)) {
+			this.selectedEntries.delete(md5)
+		} else {
+			this.selectedEntries.add(md5)
+		}
+	}
+
+	toggleSelectAll() {
+		if (!this.list) return
+
+		if (this.selectedEntries.size === this.list.entries.length) {
+			this.selectedEntries.clear()
+		} else {
+			this.selectedEntries = new Set(this.list.entries.map(e => e.md5))
+		}
+	}
+
+	isSelected(md5: string): boolean {
+		return this.selectedEntries.has(md5)
+	}
+
+	get allSelected(): boolean {
+		return this.list ? this.selectedEntries.size === this.list.entries.length && this.list.entries.length > 0 : false
+	}
+
+	get someSelected(): boolean {
+		return this.selectedEntries.size > 0 && !this.allSelected
+	}
+
+	downloadEntry(entry: SongListEntry) {
+		this.downloadService.addDownload({
+			md5: entry.md5,
+			chartId: entry.chartId,
+			hasVideoBackground: true, // Default to true since we don't cache this
+			name: entry.cache.name || 'Unknown',
+			artist: entry.cache.artist || 'Unknown',
+			album: entry.cache.album || 'Unknown',
+			genre: 'Unknown',
+			year: 'Unknown',
+			charter: entry.cache.charter || 'Unknown',
+		} as any)
+	}
+
+	downloadSelected() {
+		if (!this.list) return
+
+		for (const entry of this.list.entries) {
+			if (this.selectedEntries.has(entry.md5)) {
+				this.downloadEntry(entry)
+			}
+		}
+		this.selectedEntries.clear()
+	}
+
+	downloadAll() {
+		if (!this.list) return
+
+		for (const entry of this.list.entries) {
+			this.downloadEntry(entry)
+		}
+	}
+
+	confirmRemove(entry: SongListEntry, event: Event) {
+		event.stopPropagation()
+		this.entryToRemove = entry
+		this.removeConfirmModal.nativeElement.showModal()
+	}
+
+	removeEntry() {
+		if (this.list && this.entryToRemove) {
+			this.songListService.removeCharts(this.list.id, [this.entryToRemove.md5])
+			this.selectedEntries.delete(this.entryToRemove.md5)
+			this.entryToRemove = null
+			this.removeConfirmModal.nativeElement.close()
+		}
+	}
+
+	removeSelected() {
+		if (this.list && this.selectedEntries.size > 0) {
+			this.songListService.removeCharts(this.list.id, Array.from(this.selectedEntries))
+			this.selectedEntries.clear()
+		}
+	}
+
+	async exportList() {
+		if (this.list) {
+			await this.songListService.exportList(this.list.id)
+		}
+	}
+
+	formatDate(isoDate: string): string {
+		return new Date(isoDate).toLocaleDateString()
+	}
+}

--- a/src-angular/app/components/songlists/songlists.component.html
+++ b/src-angular/app/components/songlists/songlists.component.html
@@ -1,0 +1,183 @@
+<div class="p-8 flex flex-col gap-4 h-full">
+	<div class="flex justify-between items-center">
+		<div class="text-xl">Song Lists</div>
+		<div class="flex gap-2">
+			<button class="btn btn-neutral" (click)="importList()">
+				<i class="bi bi-download"></i>
+				Import List
+			</button>
+			<button class="btn btn-primary" (click)="openCreateModal()">
+				<i class="bi bi-plus-lg"></i>
+				Create New List
+			</button>
+		</div>
+	</div>
+
+	@if (lists.length === 0) {
+		<div class="flex-1 flex flex-col items-center justify-center text-base-content/60">
+			<i class="bi bi-collection text-6xl mb-4"></i>
+			<p class="text-lg">No song lists yet</p>
+			<p class="text-sm">Create a new list or import one to get started</p>
+		</div>
+	} @else {
+		<div class="overflow-x-auto flex-1">
+			<table class="table table-zebra">
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Description</th>
+						<th>Songs</th>
+						<th>Created</th>
+						<th>Modified</th>
+						<th class="w-32">Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					@for (list of lists; track list.id) {
+						<tr class="hover cursor-pointer" (click)="viewList(list)">
+							<td class="font-medium">{{ list.name }}</td>
+							<td class="text-base-content/70 max-w-xs truncate">{{ list.description || '-' }}</td>
+							<td>{{ list.entries.length }}</td>
+							<td>{{ formatDate(list.createdAt) }}</td>
+							<td>{{ formatDate(list.modifiedAt) }}</td>
+							<td>
+								<div class="flex gap-1">
+									<button
+										class="btn btn-ghost btn-square btn-sm tooltip"
+										data-tip="Export"
+										(click)="exportList(list, $event)">
+										<i class="bi bi-upload"></i>
+									</button>
+									<button
+										class="btn btn-ghost btn-square btn-sm tooltip text-error"
+										data-tip="Delete"
+										(click)="confirmDelete(list, $event)">
+										<i class="bi bi-trash"></i>
+									</button>
+								</div>
+							</td>
+						</tr>
+					}
+				</tbody>
+			</table>
+		</div>
+	}
+
+	<!-- Create List Modal -->
+	<dialog #createListModal class="modal">
+		<div class="modal-box bg-base-100 text-base-content">
+			<form method="dialog">
+				<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+					<i class="bi bi-x-lg text-lg"></i>
+				</button>
+			</form>
+			<h3 class="text-lg font-bold mb-4">Create New Song List</h3>
+			<div class="form-control mb-4">
+				<label class="label">
+					<span class="label-text">Name</span>
+				</label>
+				<input
+					type="text"
+					[formControl]="newListName"
+					class="input input-bordered"
+					placeholder="My Song List"
+					(keydown.enter)="createList()" />
+			</div>
+			<div class="form-control mb-4">
+				<label class="label">
+					<span class="label-text">Description (optional)</span>
+				</label>
+				<textarea
+					[formControl]="newListDescription"
+					class="textarea textarea-bordered"
+					placeholder="A collection of my favorite songs..."
+					rows="2"></textarea>
+			</div>
+			<div class="modal-action">
+				<form method="dialog">
+					<button class="btn btn-ghost">Cancel</button>
+				</form>
+				<button class="btn btn-primary" [disabled]="!newListName.valid" (click)="createList()">Create</button>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop">
+			<button>close</button>
+		</form>
+	</dialog>
+
+	<!-- Import Preview Modal -->
+	<dialog #importPreviewModal class="modal">
+		<div class="modal-box bg-base-100 text-base-content max-w-2xl">
+			<form method="dialog">
+				<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+					<i class="bi bi-x-lg text-lg"></i>
+				</button>
+			</form>
+			<h3 class="text-lg font-bold mb-4">Import Song List</h3>
+			@if (importedList) {
+				<div class="mb-4">
+					<p class="font-medium">{{ importedList.name }}</p>
+					<p class="text-sm text-base-content/70">{{ importedList.description || 'No description' }}</p>
+					<p class="text-sm text-base-content/60 mt-2">{{ importedList.entries.length }} songs</p>
+				</div>
+				<div class="max-h-64 overflow-y-auto">
+					<table class="table table-xs">
+						<thead>
+							<tr>
+								<th>Name</th>
+								<th>Artist</th>
+								<th>Charter</th>
+							</tr>
+						</thead>
+						<tbody>
+							@for (entry of importedList.entries; track entry.md5) {
+								<tr>
+									<td>{{ entry.cache.name || 'Unknown' }}</td>
+									<td>{{ entry.cache.artist || 'Unknown' }}</td>
+									<td>{{ entry.cache.charter || 'Unknown' }}</td>
+								</tr>
+							}
+						</tbody>
+					</table>
+				</div>
+			}
+			<div class="modal-action">
+				<form method="dialog">
+					<button class="btn btn-ghost">Cancel</button>
+				</form>
+				<button class="btn btn-primary" (click)="saveImportedList()">
+					<i class="bi bi-save"></i>
+					Save to My Lists
+				</button>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop">
+			<button>close</button>
+		</form>
+	</dialog>
+
+	<!-- Delete Confirmation Modal -->
+	<dialog #deleteConfirmModal class="modal">
+		<div class="modal-box bg-base-100 text-base-content">
+			<form method="dialog">
+				<button class="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+					<i class="bi bi-x-lg text-lg"></i>
+				</button>
+			</form>
+			<h3 class="text-lg font-bold mb-4">Delete Song List</h3>
+			@if (listToDelete) {
+				<p>Are you sure you want to delete "{{ listToDelete.name }}"?</p>
+				<p class="text-sm text-base-content/70 mt-2">This action cannot be undone.</p>
+			}
+			<div class="modal-action">
+				<form method="dialog">
+					<button class="btn btn-ghost">Cancel</button>
+				</form>
+				<button class="btn btn-error" (click)="deleteList()">Delete</button>
+			</div>
+		</div>
+		<form method="dialog" class="modal-backdrop">
+			<button>close</button>
+		</form>
+	</dialog>
+</div>

--- a/src-angular/app/components/songlists/songlists.component.ts
+++ b/src-angular/app/components/songlists/songlists.component.ts
@@ -1,0 +1,108 @@
+import { ChangeDetectorRef, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core'
+import { FormControl, Validators } from '@angular/forms'
+import { Router } from '@angular/router'
+
+import { SongList } from '../../../../src-shared/interfaces/songlist.interface.js'
+import { SongListService } from '../../core/services/songlist.service'
+
+@Component({
+	selector: 'app-songlists',
+	templateUrl: './songlists.component.html',
+	standalone: false,
+})
+export class SongListsComponent implements OnInit, OnDestroy {
+	@ViewChild('createListModal') createListModal: ElementRef<HTMLDialogElement>
+	@ViewChild('importPreviewModal') importPreviewModal: ElementRef<HTMLDialogElement>
+	@ViewChild('deleteConfirmModal') deleteConfirmModal: ElementRef<HTMLDialogElement>
+
+	lists: SongList[] = []
+	newListName = new FormControl<string>('', { nonNullable: true, validators: [Validators.required] })
+	newListDescription = new FormControl<string>('', { nonNullable: true })
+
+	importedList: SongList | null = null
+	listToDelete: SongList | null = null
+
+	private listsChangedSub: any
+
+	constructor(
+		public songListService: SongListService,
+		private ref: ChangeDetectorRef,
+		private router: Router,
+	) { }
+
+	ngOnInit() {
+		this.lists = this.songListService.getLists()
+		this.listsChangedSub = this.songListService.listsChanged.subscribe(lists => {
+			this.lists = lists
+			this.ref.detectChanges()
+		})
+	}
+
+	ngOnDestroy() {
+		if (this.listsChangedSub) {
+			this.listsChangedSub.unsubscribe()
+		}
+	}
+
+	openCreateModal() {
+		this.newListName.reset()
+		this.newListDescription.reset()
+		this.createListModal.nativeElement.showModal()
+	}
+
+	async createList() {
+		if (this.newListName.valid) {
+			await this.songListService.createList(
+				this.newListName.value.trim(),
+				this.newListDescription.value.trim()
+			)
+			this.createListModal.nativeElement.close()
+		}
+	}
+
+	viewList(list: SongList) {
+		this.router.navigate(['/lists', list.id])
+	}
+
+	async exportList(list: SongList, event: Event) {
+		event.stopPropagation()
+		const success = await this.songListService.exportList(list.id)
+		if (success) {
+			// Could show success toast
+		}
+	}
+
+	confirmDelete(list: SongList, event: Event) {
+		event.stopPropagation()
+		this.listToDelete = list
+		this.deleteConfirmModal.nativeElement.showModal()
+	}
+
+	deleteList() {
+		if (this.listToDelete) {
+			this.songListService.deleteList(this.listToDelete.id)
+			this.listToDelete = null
+			this.deleteConfirmModal.nativeElement.close()
+		}
+	}
+
+	async importList() {
+		const list = await this.songListService.importList()
+		if (list) {
+			this.importedList = list
+			this.importPreviewModal.nativeElement.showModal()
+		}
+	}
+
+	saveImportedList() {
+		if (this.importedList) {
+			this.songListService.saveImportedList(this.importedList)
+			this.importedList = null
+			this.importPreviewModal.nativeElement.close()
+		}
+	}
+
+	formatDate(isoDate: string): string {
+		return new Date(isoDate).toLocaleDateString()
+	}
+}

--- a/src-angular/app/components/toolbar/toolbar.component.html
+++ b/src-angular/app/components/toolbar/toolbar.component.html
@@ -1,6 +1,7 @@
 <div class="navbar p-0 min-h-0 bg-base-100" style="-webkit-app-region: drag">
 	<div style="-webkit-app-region: no-drag">
 		<button class="btn btn-ghost rounded-none" routerLinkActive="btn-active" routerLink="/browse">Browse</button>
+		<button class="btn btn-ghost rounded-none" routerLinkActive="btn-active" routerLink="/lists">Lists</button>
 		<button class="btn btn-ghost rounded-none" routerLinkActive="btn-active" routerLink="/tools">Tools</button>
 		<button class="btn btn-ghost rounded-none flex flex-nowrap" routerLinkActive="btn-active" routerLink="/settings">
 			<i *ngIf="updateAvailable === 'error'" class="bi bi-exclamation-triangle-fill text-warning"></i>

--- a/src-angular/app/core/services/songlist.service.ts
+++ b/src-angular/app/core/services/songlist.service.ts
@@ -1,0 +1,210 @@
+import { EventEmitter, Injectable } from '@angular/core'
+
+import { SongList, SongListEntry, SongListStorage } from '../../../../src-shared/interfaces/songlist.interface.js'
+import { ChartData } from '../../../../src-shared/interfaces/search.interface.js'
+
+@Injectable({
+	providedIn: 'root',
+})
+export class SongListService {
+
+	private storage: SongListStorage = { version: 1, lists: [] }
+
+	/** Emits when the lists have been modified */
+	listsChanged = new EventEmitter<SongList[]>()
+
+	constructor() { }
+
+	/**
+	 * Loads song lists from storage. Should be called at app startup.
+	 */
+	async loadLists() {
+		this.storage = await window.electron.invoke.getSongLists()
+	}
+
+	/**
+	 * @returns all song lists
+	 */
+	getLists(): SongList[] {
+		return this.storage.lists
+	}
+
+	/**
+	 * @returns a specific song list by ID, or undefined if not found
+	 */
+	getList(id: string): SongList | undefined {
+		return this.storage.lists.find(l => l.id === id)
+	}
+
+	/**
+	 * Creates a new song list with the given name and description.
+	 * @returns the created SongList
+	 */
+	async createList(name: string, description: string = ''): Promise<SongList> {
+		const newList = await window.electron.invoke.createSongList({ name, description })
+		this.storage.lists.push(newList)
+		this.listsChanged.emit(this.storage.lists)
+		return newList
+	}
+
+	/**
+	 * Updates an existing song list.
+	 */
+	updateList(list: SongList) {
+		window.electron.emit.updateSongList(list)
+		const index = this.storage.lists.findIndex(l => l.id === list.id)
+		if (index !== -1) {
+			list.modifiedAt = new Date().toISOString()
+			this.storage.lists[index] = list
+			this.listsChanged.emit(this.storage.lists)
+		}
+	}
+
+	/**
+	 * Deletes a song list by ID.
+	 */
+	deleteList(id: string) {
+		window.electron.emit.deleteSongList(id)
+		this.storage.lists = this.storage.lists.filter(l => l.id !== id)
+		this.listsChanged.emit(this.storage.lists)
+	}
+
+	/**
+	 * Converts ChartData to SongListEntry for storage.
+	 */
+	private chartToEntry(chart: ChartData): SongListEntry {
+		return {
+			md5: chart.md5,
+			chartId: chart.chartId,
+			cache: {
+				name: chart.chartName || chart.name,
+				artist: chart.artist,
+				album: chart.chartAlbum || chart.album,
+				charter: chart.charter,
+			},
+			addedAt: new Date().toISOString(),
+		}
+	}
+
+	/**
+	 * Adds charts to a song list.
+	 */
+	addCharts(listId: string, charts: ChartData[]) {
+		const entries = charts.map(chart => this.chartToEntry(chart))
+		window.electron.emit.addToSongList({ listId, entries })
+
+		// Optimistically update local state
+		const list = this.storage.lists.find(l => l.id === listId)
+		if (list) {
+			const existingMd5s = new Set(list.entries.map(e => e.md5))
+			const newEntries = entries.filter(e => !existingMd5s.has(e.md5))
+			list.entries.push(...newEntries)
+			list.modifiedAt = new Date().toISOString()
+			this.listsChanged.emit(this.storage.lists)
+		}
+	}
+
+	/**
+	 * Removes charts from a song list by their md5 hashes.
+	 */
+	removeCharts(listId: string, md5s: string[]) {
+		window.electron.emit.removeFromSongList({ listId, md5s })
+
+		// Optimistically update local state
+		const list = this.storage.lists.find(l => l.id === listId)
+		if (list) {
+			const md5Set = new Set(md5s)
+			list.entries = list.entries.filter(e => !md5Set.has(e.md5))
+			list.modifiedAt = new Date().toISOString()
+			this.listsChanged.emit(this.storage.lists)
+		}
+	}
+
+	/**
+	 * Exports a song list to a .bridgelist file.
+	 * Opens a save dialog and exports to the selected path.
+	 * @returns true if export was successful, false otherwise
+	 */
+	async exportList(listId: string): Promise<boolean> {
+		const list = this.getList(listId)
+		if (!list) { return false }
+
+		const result = await window.electron.invoke.showSaveDialog({
+			title: 'Export Song List',
+			defaultPath: `${list.name}.bridgelist`,
+			filters: [
+				{ name: 'Bridge Song List', extensions: ['bridgelist'] },
+			],
+		})
+
+		if (result.canceled || !result.filePath) { return false }
+
+		const exportResult = await window.electron.invoke.exportSongList({
+			listId,
+			filePath: result.filePath,
+		})
+
+		return exportResult.success
+	}
+
+	/**
+	 * Imports a .bridgelist file.
+	 * Opens a file dialog and imports the selected file.
+	 * @returns the imported SongList if successful, null otherwise
+	 */
+	async importList(): Promise<SongList | null> {
+		const result = await window.electron.invoke.showOpenDialog({
+			title: 'Import Song List',
+			filters: [
+				{ name: 'Bridge Song List', extensions: ['bridgelist'] },
+			],
+			properties: ['openFile'],
+		})
+
+		if (result.canceled || !result.filePaths.length) { return null }
+
+		const importResult = await window.electron.invoke.importSongList(result.filePaths[0])
+
+		if (!importResult.success || !importResult.list) {
+			// Could show error toast here
+			console.error('Import failed:', importResult.error)
+			return null
+		}
+
+		return importResult.list
+	}
+
+	/**
+	 * Saves an imported song list to storage.
+	 */
+	saveImportedList(list: SongList) {
+		window.electron.emit.saveImportedSongList(list)
+		this.storage.lists.push(list)
+		this.listsChanged.emit(this.storage.lists)
+	}
+
+	/**
+	 * Checks if a chart is in a specific list.
+	 */
+	isChartInList(listId: string, md5: string): boolean {
+		const list = this.getList(listId)
+		return list ? list.entries.some(e => e.md5 === md5) : false
+	}
+
+	/**
+	 * Gets all lists that contain a specific chart.
+	 */
+	getListsContainingChart(md5: string): SongList[] {
+		return this.storage.lists.filter(list =>
+			list.entries.some(e => e.md5 === md5)
+		)
+	}
+
+	/**
+	 * Refreshes the lists from storage.
+	 */
+	async refresh() {
+		await this.loadLists()
+		this.listsChanged.emit(this.storage.lists)
+	}
+}

--- a/src-electron/IpcHandler.ts
+++ b/src-electron/IpcHandler.ts
@@ -2,6 +2,18 @@ import { IpcInvokeHandlers, IpcToMainEmitHandlers } from '../src-shared/interfac
 import { download } from './ipc/DownloadHandler.ipc.js'
 import { scanIssues } from './ipc/issue-scan/IssueScanHandler.ipc.js'
 import { getSettings, setSettings } from './ipc/SettingsHandler.ipc.js'
+import {
+	addToSongList,
+	createSongList,
+	deleteSongList,
+	exportSongList,
+	getSongLists,
+	importSongList,
+	removeFromSongList,
+	saveImportedSongList,
+	showSaveDialog,
+	updateSongList,
+} from './ipc/SongListHandler.ipc.js'
 import { downloadUpdate, getCurrentVersion, getUpdateAvailable, quitAndInstall, retryUpdate } from './ipc/UpdateHandler.ipc.js'
 import { getPlatform, getThemeColors, isMaximized, maximize, minimize, openUrl, quit, restore, showFile, showFolder, showOpenDialog, toggleDevTools } from './ipc/UtilHandlers.ipc.js'
 
@@ -14,6 +26,12 @@ export function getIpcInvokeHandlers(): IpcInvokeHandlers {
 		isMaximized,
 		showOpenDialog,
 		getThemeColors,
+		// Song list handlers
+		getSongLists,
+		exportSongList,
+		importSongList,
+		showSaveDialog,
+		createSongList,
 	}
 }
 
@@ -33,5 +51,11 @@ export function getIpcToMainEmitHandlers(): IpcToMainEmitHandlers {
 		showFile,
 		showFolder,
 		scanIssues,
+		// Song list handlers
+		updateSongList,
+		deleteSongList,
+		addToSongList,
+		removeFromSongList,
+		saveImportedSongList,
 	}
 }

--- a/src-electron/ipc/SongListHandler.ipc.ts
+++ b/src-electron/ipc/SongListHandler.ipc.ts
@@ -1,0 +1,209 @@
+import { randomUUID } from 'crypto'
+import { dialog, SaveDialogOptions } from 'electron'
+import { readFileSync } from 'fs'
+import { outputFile } from 'fs-extra'
+import { gunzip, gzip } from 'zlib'
+import { promisify } from 'util'
+import { inspect } from 'util'
+
+import { dataPath, songListsPath } from '../../src-shared/Paths.js'
+import {
+	BridgelistFile,
+	SongList,
+	SongListEntry,
+	SongListExportResult,
+	SongListImportResult,
+	SongListStorage,
+} from '../../src-shared/interfaces/songlist.interface.js'
+import { mainWindow } from '../main.js'
+import { getCurrentVersion } from './UpdateHandler.ipc.js'
+
+const gzipAsync = promisify(gzip)
+const gunzipAsync = promisify(gunzip)
+
+const defaultStorage: SongListStorage = {
+	version: 1,
+	lists: [],
+}
+
+let songListStorage: SongListStorage = readSongLists()
+
+function readSongLists(): SongListStorage {
+	try {
+		const data = JSON.parse(readFileSync(songListsPath, 'utf8')) as SongListStorage
+		return data
+	} catch (err) {
+		if (err?.code !== 'ENOENT') {
+			console.error('Failed to load song lists. Default storage will be used.\n' + inspect(err))
+		}
+		return { ...defaultStorage, lists: [] }
+	}
+}
+
+async function writeSongLists() {
+	try {
+		await outputFile(songListsPath, JSON.stringify(songListStorage, undefined, 2), { encoding: 'utf8' })
+	} catch (err) {
+		console.error('Failed to save song lists.\n' + inspect(err))
+	}
+}
+
+/**
+ * @returns the current song list storage.
+ */
+export async function getSongLists(): Promise<SongListStorage> {
+	return songListStorage
+}
+
+/**
+ * Creates a new song list with the given name and description.
+ * @returns the created SongList with its assigned ID.
+ */
+export async function createSongList(data: { name: string; description: string }): Promise<SongList> {
+	const now = new Date().toISOString()
+	const newList: SongList = {
+		id: randomUUID(),
+		name: data.name,
+		description: data.description,
+		createdAt: now,
+		modifiedAt: now,
+		entries: [],
+	}
+	songListStorage.lists.push(newList)
+	await writeSongLists()
+	return newList
+}
+
+/**
+ * Updates an existing song list.
+ */
+export function updateSongList(list: SongList) {
+	const index = songListStorage.lists.findIndex(l => l.id === list.id)
+	if (index !== -1) {
+		list.modifiedAt = new Date().toISOString()
+		songListStorage.lists[index] = list
+		writeSongLists()
+	}
+}
+
+/**
+ * Deletes a song list by ID.
+ */
+export function deleteSongList(listId: string) {
+	songListStorage.lists = songListStorage.lists.filter(l => l.id !== listId)
+	writeSongLists()
+}
+
+/**
+ * Adds entries to a song list.
+ */
+export function addToSongList(data: { listId: string; entries: SongListEntry[] }) {
+	const list = songListStorage.lists.find(l => l.id === data.listId)
+	if (list) {
+		// Avoid duplicates by checking md5
+		const existingMd5s = new Set(list.entries.map(e => e.md5))
+		const newEntries = data.entries.filter(e => !existingMd5s.has(e.md5))
+		list.entries.push(...newEntries)
+		list.modifiedAt = new Date().toISOString()
+		writeSongLists()
+	}
+}
+
+/**
+ * Removes entries from a song list by their md5 hashes.
+ */
+export function removeFromSongList(data: { listId: string; md5s: string[] }) {
+	const list = songListStorage.lists.find(l => l.id === data.listId)
+	if (list) {
+		const md5Set = new Set(data.md5s)
+		list.entries = list.entries.filter(e => !md5Set.has(e.md5))
+		list.modifiedAt = new Date().toISOString()
+		writeSongLists()
+	}
+}
+
+/**
+ * Exports a song list to a .bridgelist file (gzip compressed JSON).
+ */
+export async function exportSongList(data: { listId: string; filePath: string }): Promise<SongListExportResult> {
+	try {
+		const list = songListStorage.lists.find(l => l.id === data.listId)
+		if (!list) {
+			return { success: false, error: 'Song list not found' }
+		}
+
+		const version = await getCurrentVersion()
+		const bridgelistFile: BridgelistFile = {
+			magic: 'BRIDGELIST',
+			formatVersion: 1,
+			data: list,
+			createdBy: `Bridge ${version}`,
+		}
+
+		const jsonString = JSON.stringify(bridgelistFile)
+		const compressed = await gzipAsync(jsonString)
+		await outputFile(data.filePath, compressed)
+
+		return { success: true }
+	} catch (err) {
+		console.error('Failed to export song list.\n' + inspect(err))
+		return { success: false, error: err?.message || 'Unknown error' }
+	}
+}
+
+/**
+ * Imports a .bridgelist file and returns the parsed song list.
+ */
+export async function importSongList(filePath: string): Promise<SongListImportResult> {
+	try {
+		const compressed = readFileSync(filePath)
+		const decompressed = await gunzipAsync(compressed)
+		const bridgelistFile = JSON.parse(decompressed.toString('utf8')) as BridgelistFile
+
+		// Validate magic header
+		if (bridgelistFile.magic !== 'BRIDGELIST') {
+			return { success: false, error: 'Invalid file format: not a valid .bridgelist file' }
+		}
+
+		// Validate format version
+		if (bridgelistFile.formatVersion !== 1) {
+			return { success: false, error: `Unsupported format version: ${bridgelistFile.formatVersion}` }
+		}
+
+		// Generate a new ID for the imported list to avoid conflicts
+		const importedList: SongList = {
+			...bridgelistFile.data,
+			id: randomUUID(),
+			modifiedAt: new Date().toISOString(),
+		}
+
+		return { success: true, list: importedList }
+	} catch (err) {
+		console.error('Failed to import song list.\n' + inspect(err))
+
+		// Provide user-friendly error messages
+		if (err?.code === 'Z_DATA_ERROR') {
+			return { success: false, error: 'Invalid file: not a valid compressed .bridgelist file' }
+		}
+		if (err instanceof SyntaxError) {
+			return { success: false, error: 'Invalid file: corrupted data' }
+		}
+
+		return { success: false, error: err?.message || 'Unknown error' }
+	}
+}
+
+/**
+ * Shows a save dialog and returns the selected path.
+ */
+export function showSaveDialog(options: SaveDialogOptions) {
+	return dialog.showSaveDialog(mainWindow, options)
+}
+
+/**
+ * Adds an imported song list to storage.
+ */
+export function saveImportedSongList(list: SongList) {
+	songListStorage.lists.push(list)
+	writeSongLists()
+}

--- a/src-electron/preload.ts
+++ b/src-electron/preload.ts
@@ -25,6 +25,12 @@ const electronApi: ContextBridgeApi = {
 		isMaximized: getInvoker('isMaximized'),
 		showOpenDialog: getInvoker('showOpenDialog'),
 		getThemeColors: getInvoker('getThemeColors'),
+		// Song list handlers
+		getSongLists: getInvoker('getSongLists'),
+		exportSongList: getInvoker('exportSongList'),
+		importSongList: getInvoker('importSongList'),
+		showSaveDialog: getInvoker('showSaveDialog'),
+		createSongList: getInvoker('createSongList'),
 	},
 	emit: {
 		download: getEmitter('download'),
@@ -41,6 +47,12 @@ const electronApi: ContextBridgeApi = {
 		showFolder: getEmitter('showFolder'),
 		showFile: getEmitter('showFile'),
 		scanIssues: getEmitter('scanIssues'),
+		// Song list handlers
+		updateSongList: getEmitter('updateSongList'),
+		deleteSongList: getEmitter('deleteSongList'),
+		addToSongList: getEmitter('addToSongList'),
+		removeFromSongList: getEmitter('removeFromSongList'),
+		saveImportedSongList: getEmitter('saveImportedSongList'),
 	},
 	on: {
 		errorLog: getListenerAdder('errorLog'),

--- a/src-shared/Paths.ts
+++ b/src-shared/Paths.ts
@@ -5,5 +5,6 @@ import { join } from 'path'
 export const dataPath = join(app.getPath('userData'), 'bridge_data')
 export const libraryPath = join(dataPath, 'library.db')
 export const settingsPath = join(dataPath, 'settings.json')
+export const songListsPath = join(dataPath, 'songlists.json')
 export const tempPath = join(dataPath, 'temp')
 export const themesPath = join(dataPath, 'themes')

--- a/src-shared/interfaces/ipc.interface.ts
+++ b/src-shared/interfaces/ipc.interface.ts
@@ -1,8 +1,9 @@
-import { OpenDialogOptions, OpenDialogReturnValue } from 'electron'
+import { OpenDialogOptions, OpenDialogReturnValue, SaveDialogOptions, SaveDialogReturnValue } from 'electron'
 import { UpdateInfo } from 'electron-updater'
 
 import { Settings } from '../Settings.js'
 import { Download, DownloadProgress } from './download.interface.js'
+import { SongList, SongListEntry, SongListExportResult, SongListImportResult, SongListStorage } from './songlist.interface.js'
 import { ThemeColors } from './theme.interface.js'
 import { UpdateProgress } from './update.interface.js'
 
@@ -50,6 +51,27 @@ export interface IpcInvokeEvents {
 		input: string
 		output: ThemeColors | null
 	}
+	// Song list IPC events
+	getSongLists: {
+		input: void
+		output: SongListStorage
+	}
+	exportSongList: {
+		input: { listId: string; filePath: string }
+		output: SongListExportResult
+	}
+	importSongList: {
+		input: string
+		output: SongListImportResult
+	}
+	showSaveDialog: {
+		input: SaveDialogOptions
+		output: SaveDialogReturnValue
+	}
+	createSongList: {
+		input: { name: string; description: string }
+		output: SongList
+	}
 }
 
 export type IpcInvokeHandlers = {
@@ -75,6 +97,12 @@ export interface IpcToMainEmitEvents {
 	showFolder: string
 	showFile: string
 	scanIssues: void
+	// Song list emit events
+	updateSongList: SongList
+	deleteSongList: string
+	addToSongList: { listId: string; entries: SongListEntry[] }
+	removeFromSongList: { listId: string; md5s: string[] }
+	saveImportedSongList: SongList
 }
 
 export type IpcToMainEmitHandlers = {

--- a/src-shared/interfaces/songlist.interface.ts
+++ b/src-shared/interfaces/songlist.interface.ts
@@ -1,0 +1,83 @@
+/**
+ * Cached metadata for offline preview of a song list entry.
+ */
+export interface SongListEntryCache {
+	name: string | null
+	artist: string | null
+	album: string | null
+	charter: string | null
+}
+
+/**
+ * A single entry in a song list. Contains minimal data for API lookup
+ * plus cached metadata for offline preview.
+ */
+export interface SongListEntry {
+	/** Primary identifier - MD5 hash of chart folder/sng file */
+	md5: string
+	/** Database chart ID for API lookup */
+	chartId: number
+	/** Cached display metadata for offline preview */
+	cache: SongListEntryCache
+	/** Timestamp when entry was added to the list (ISO 8601) */
+	addedAt: string
+}
+
+/**
+ * A named collection of songs that can be managed, exported, and shared.
+ */
+export interface SongList {
+	/** Unique identifier for the list (UUID v4) */
+	id: string
+	/** User-defined name for the list */
+	name: string
+	/** Optional description */
+	description: string
+	/** When the list was created (ISO 8601) */
+	createdAt: string
+	/** When the list was last modified (ISO 8601) */
+	modifiedAt: string
+	/** The songs in this list */
+	entries: SongListEntry[]
+}
+
+/**
+ * Root storage structure for all local song lists.
+ */
+export interface SongListStorage {
+	/** Schema version for future migrations */
+	version: 1
+	/** All local song lists */
+	lists: SongList[]
+}
+
+/**
+ * File format for exported .bridgelist files.
+ */
+export interface BridgelistFile {
+	/** Magic identifier for file validation */
+	magic: 'BRIDGELIST'
+	/** File format version */
+	formatVersion: 1
+	/** The song list data */
+	data: SongList
+	/** App version that created this file */
+	createdBy?: string
+}
+
+/**
+ * Result of importing a .bridgelist file.
+ */
+export interface SongListImportResult {
+	success: boolean
+	list?: SongList
+	error?: string
+}
+
+/**
+ * Result of exporting a song list.
+ */
+export interface SongListExportResult {
+	success: boolean
+	error?: string
+}


### PR DESCRIPTION
- Add Lists tab in toolbar for managing song lists
- Create, edit, and delete named lists with descriptions
- Add songs to lists from chart sidebar or multi-select in browse view
- Export lists to .bridgelist files (gzip compressed JSON)
- Import .bridgelist files shared by others
- View list details with cached metadata for offline preview
- Persist lists to songlists.json in user data directory

Fix: Use backend-generated list ID to ensure export and persistence work correctly